### PR TITLE
Add LastFM Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ cython_debug/
 data/top players (200).json
 data/anime.json
 docs/
+.DS_Store

--- a/helper_objects.py
+++ b/helper_objects.py
@@ -649,3 +649,151 @@ class TriviaHelper:
     @property
     def is_in_progress(self):
         return self.answer is not None
+
+
+def get_obj(data, key, cls, default=None):
+    return default if (value:=data.get(key)) is None else cls(value)
+
+
+class MWSenseCalledAlso:
+    __slots__ = ("intro", "cats")
+
+    def __init__(self, data):
+        self.intro: str | None = data.get("intro")
+        self.cats: list | None = data.get("cats")
+
+
+class MWSenseBiographicalName:
+    __slots__ = ("pname", "sname", "altname", "prs")
+
+    def __init__(self, data):
+        self.pname: str | None = data.get("pname")
+        self.sname: str | None = data.get("sname")
+        self.altname: str | None = data.get("altname")
+        self.prs: list | None = data.get("prs")
+
+
+class MWSenseDefinitionText:
+    __slots__ = ("content",)
+
+    def __init__(self, data):
+        self.content: str = data
+
+
+class MWSenseRunIn:
+    __slots__ = ("items",)
+
+    def __init__(self, data):
+        self.items: list = data
+
+
+class MWSenseSupplementalInfo:
+    __slots__ = ("items",)
+
+    def __init__(self, data):
+        self.items: list = data
+
+
+class MWSenseUsage:
+    __slots__ = ("items",)
+
+    def __init__(self, data):
+        self.items: list = data
+
+
+class MWSenseVerbalIllustration:
+    __slots__ = ("items",)
+
+    def __init__(self, data):
+        self.items: list = data
+
+
+SENSE_DEF_CONTENTS = (
+    MWSenseDefinitionText |
+    MWSenseBiographicalName |
+    MWSenseCalledAlso |
+    MWSenseRunIn |
+    MWSenseSupplementalInfo |
+    MWSenseUsage |
+    MWSenseVerbalIllustration
+)
+
+
+class MWSenseDefinition:
+    __slots__ = ("items",)
+
+    def __init__(self, data):
+        self.items: list[SENSE_DEF_CONTENTS] = list(map(self.parse_content_item, data))
+
+    @staticmethod
+    def parse_content_item(data) -> SENSE_DEF_CONTENTS:
+        return {
+            "text": MWSenseDefinitionText,
+            "bnw": MWSenseBiographicalName,
+            "ca": MWSenseCalledAlso,
+            "ri": MWSenseRunIn,
+            "snote": MWSenseSupplementalInfo,
+            "uns": MWSenseUsage,
+            "vis": MWSenseVerbalIllustration
+        }[data[0]](data[1])
+
+
+class MWSense:
+    __slots__ = (
+        "etymology",
+        "inflections",
+        "labels",
+        "pronunciations",
+        "divided_sense",
+        "grammatical_label",
+        "status_labels",
+        "sense_number",
+        "variants",
+        "definition",
+        "sense_divider"
+    )
+
+    def __init__(self, data):
+        self.etymology: list | None = data.get("et")
+        self.inflections: list | None = data.get("ins")
+        self.labels: list | None = data.get("lbs")
+        self.pronunciations: list | None = data.get("prs")
+        self.divided_sense: MWSense | None = get_obj(data, "sdsense", MWSense)
+        self.grammatical_label: str | None = data.get("sgram")
+        self.status_labels: list | None = data.get("sls")
+        self.sense_number: str | None = data.get("sn")
+        self.variants: list | None = data.get("vrs")
+        self.definition: MWSenseDefinition | None = get_obj(data, "dt", MWSenseDefinition)
+        self.sense_divider: str | None = data.get("sd")
+
+
+class MWBindingSense:
+    __slots__ = ("sense",)
+
+    def __init__(self, data):
+        self.sense: MWSense = MWSense(data["sense"])
+
+
+class MWSequenceSense:
+    __slots__ = ("senses",)
+
+    def __init__(self, data):
+        self.senses: list[MWSense | MWBindingSense | list[MWSense | MWBindingSense]] = list(map(self.parse_sense, data))
+
+    @staticmethod
+    def parse_sense(data) -> MWSense | MWBindingSense | list[MWSense | MWBindingSense]:
+
+        return {
+            "sense": MWSense,
+            "sen": MWSense,
+            "pseq": lambda data: [MWSense(elm[1]) if elm[0] == "sense" else MWBindingSense(elm[1]) for elm in data],
+            "bs": MWBindingSense
+        }[data[0]](data[1])
+
+
+class MWDefinition:
+    __slots__ = ("verb_divider", "sense_sequences")
+
+    def __init__(self, data):
+        self.verb_divider: str | None = data.get("vd")
+        self.sense_sequences: list[MWSequenceSense] = list(map(MWSequenceSense, data.get("sseq", [])))

--- a/lastfm.py
+++ b/lastfm.py
@@ -1,0 +1,44 @@
+import requests
+import os
+import json
+from dotenv import load_dotenv
+
+load_dotenv()
+
+lastfm_token = os.getenv("LASTFM_TOKEN")
+
+
+class LastFM():
+    def __init__(self):
+        self.lastfm_token = lastfm_token
+
+    async def get_lastfm_user(self, user):
+        self.params = {
+            'api_key': self.lastfm_token,
+            'user': user,
+            'method': 'user.getinfo',
+            'format': 'json'
+        }
+        response = requests.get(
+                'http://ws.audioscrobbler.com/2.0/', params=self.params)
+
+        if response.status_code == 200:
+            response_json = json.loads(response.text)
+            return response.json()
+        
+        else:
+            return None
+
+    def get_recent_song(self, user):
+        self.params = {
+            'method': 'user.getrecenttracks',
+            'user': user,
+            'api_key': self.lastfm_token,
+            'extended': 1,
+            'limit': 1,
+            'format': 'json',
+        }
+        response = requests.get(
+            'http://ws.audioscrobbler.com/2.0/', params=self.params)
+        print(f"Response json: {response.json()}")
+        return response.json()

--- a/lastfm.py
+++ b/lastfm.py
@@ -1,44 +1,35 @@
 import requests
 import os
-import json
-from dotenv import load_dotenv
-
-load_dotenv()
-
-lastfm_token = os.getenv("LASTFM_TOKEN")
 
 
-class LastFM():
+lastfm_token = os.getenv("LASTFM_API_KEY")
+
+
+class LastFMClient:
     def __init__(self):
         self.lastfm_token = lastfm_token
 
-    async def get_lastfm_user(self, user):
-        self.params = {
-            'api_key': self.lastfm_token,
-            'user': user,
-            'method': 'user.getinfo',
-            'format': 'json'
+    def get_params(self, method, **kwargs):
+        return {
+            "api_key": self.lastfm_token,
+            "method": method,
+            "format": "json",
+            **kwargs
         }
-        response = requests.get(
-                'http://ws.audioscrobbler.com/2.0/', params=self.params)
 
-        if response.status_code == 200:
-            response_json = json.loads(response.text)
-            return response.json()
-        
-        else:
-            return None
+    def return_response(self, resp):
+        try:
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as err:
+            print(f"Lastfm request failed: {err}\n{resp.text}")
+
+    def get_lastfm_user(self, user):
+        params = self.get_params("user.getinfo", user=user)
+        resp = requests.get("http://ws.audioscrobbler.com/2.0/", params=params)
+        return self.return_response(resp)
 
     def get_recent_song(self, user):
-        self.params = {
-            'method': 'user.getrecenttracks',
-            'user': user,
-            'api_key': self.lastfm_token,
-            'extended': 1,
-            'limit': 1,
-            'format': 'json',
-        }
-        response = requests.get(
-            'http://ws.audioscrobbler.com/2.0/', params=self.params)
-        print(f"Response json: {response.json()}")
-        return response.json()
+        params = self.get_params("user.getrecenttracks", user=user, extended=1, limit=1)
+        resp = requests.get("http://ws.audioscrobbler.com/2.0/", params)
+        return self.return_response(resp)

--- a/main.py
+++ b/main.py
@@ -2140,17 +2140,6 @@ class Bot:
 
         await self.send_message(ctx.channel, f"@{ctx.user.display_name} Linked {username} to your account.")
     
-    @command_manager.command("lastfm_username", aliases=["fmusername", "fmuser"])
-    async def lastfm_username(self, ctx):
-        lastfm_user = self.database.get_lastfm_user_from_user_id(ctx.user_id)
-        if lastfm_user is None:
-            return await self.send_message(
-                ctx.channel,
-                f"@{ctx.user.display_name} There is no username linked to your account."
-            )
-
-        await self.send_message(ctx.channel, f"@{ctx.user.display_name} You're linked to {lastfm_user[0]} for lastfm")
-    
     @command_manager.command("lastfm_np", aliases=["fmnp"])
     async def lastfm_np(self, ctx):
         lastfm_user = self.database.get_lastfm_user_from_user_id(ctx.user_id)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from get_top_players import Client
 from get_popular_anime import create_list as create_anime_list
 from sql import Database, USER_SETTINGS
 from emotes import EmoteRequester
+from lastfm import LastFM
 from helper_objects import *
 from context import *
 from util import *
@@ -155,6 +156,9 @@ class Bot:
         self.osu_lock = asyncio.Lock()
 
         self.message_buffer = []
+
+        # lastfm
+        self.lastfm = LastFM()
 
     # Util
 
@@ -349,7 +353,6 @@ class Bot:
 
     async def connect(self):
         await self.ws.send(f"PASS {self.oauth}")
-        print(f"> PASS {self.oauth}")
         await self.ws.send(f"NICK {self.username}")
         print(f"> NICK {self.username}")
 
@@ -1812,6 +1815,53 @@ class Bot:
     async def offline_chat_osu_leaderboard(self, ctx):
         await self.send_message(ctx.channel, f"@{ctx.user.display_name} https://bot.sheppsu.me/osu/")
 
+    # lastfm
+
+    @command_manager.command("lastfm_link")
+    async def link_lastfm(self, ctx):
+        args = ctx.get_args('ascii')
+        if len(args) == 0 or args[0].strip() == "":
+            return await self.send_message(ctx.channel, f"@{ctx.user.display_name} Please specify a username.")
+
+        username = " ".join(args).strip()
+        lastfm_username = await self.lastfm.get_lastfm_user(username)
+
+        if lastfm_username is None:
+            return await self.send_message(ctx.channel, f"@{ctx.user.display_name} User {username} not found.")
+
+        lastfm_user = self.database.get_lastfm_user_from_user_id(ctx.user_id)
+
+        if lastfm_user is not None:
+            self.database.update_lastfm_data(ctx.user_id, lastfm_username)
+        else:
+            self.database.new_lastfm_data(ctx.user_id, lastfm_username)
+
+        await self.send_message(ctx.channel, f"@{ctx.user.display_name} Linked {lastfm_username['user']['name']} to your account.")
+    
+    @command_manager.command("lastfm_username")
+    async def lastfm_username(self, ctx):
+        lastfm_user = self.database.get_lastfm_user_from_user_id(ctx.user_id)
+        if lastfm_user == None:
+            await self.send_message(ctx.channel, f"@{ctx.user.display_name} There is no username linked to your account.")
+        else:
+            await self.send_message(ctx.channel, f"@{ctx.user.display_name} Your username is {lastfm_user[0]}")
+    
+    @command_manager.command("np")
+    async def lastfm_np(self, ctx):
+        lastfm_user = self.database.get_lastfm_user_from_user_id(ctx.user_id)
+        if lastfm_user == None:
+            return await self.send_message(ctx.channel, f"@{ctx.user.display_name} You don't have a username linked to LastFM, you can do !lastfm_link *username* to link your account.")
+        
+        recent_song = self.lastfm.get_recent_song(lastfm_user[0])
+
+        if "@attr" in recent_song['recenttracks']['track'][0]:
+            song_title = recent_song['recenttracks']['track'][0]['name']
+            song_artist = recent_song['recenttracks']['track'][0]['artist']['name']
+            song_url = recent_song['recenttracks']['track'][0]['url']
+
+            await self.send_message(ctx.channel, f"Now playing for {lastfm_user[0]}: {song_artist} - {song_title} | {song_url}")
+        else:
+            await self.send_message(ctx.channel, f"@{ctx.user.display_name} You are not currently playing anything.")
 
 if __name__ == "__main__":
     bot = Bot(command_manager)

--- a/sql.py
+++ b/sql.py
@@ -267,6 +267,22 @@ class Database:
         timezone = cursor.fetchone()
         return timezone[0] if timezone else None
 
+    # lastfm
+
+    def new_lastfm_data(self, user_id, lastfm_username):
+        self.get_cursor().execute(f"INSERT INTO lastfm (user_id, lastfm_user) VALUES ({user_id}, '{lastfm_username['user']['name']}')")
+        self.database.commit()
+
+    def update_lastfm_data(self, user_id, lastfm_username):
+        self.get_cursor().execute(f"UPDATE lastfm SET lastfm_user = '{lastfm_username['user']['name']}' WHERE user_id = '{user_id}'")
+        self.database.commit()
+
+    def get_lastfm_user_from_user_id(self, user_id):
+        cursor = self.get_cursor()
+        cursor.execute(f"SELECT lastfm_user FROM lastfm WHERE user_id = {user_id}")
+        lastfm_user = cursor.fetchone()
+        return lastfm_user if lastfm_user else None
+
     # misc
 
     def save_messages(self, ctx, buffer):

--- a/sql.py
+++ b/sql.py
@@ -313,6 +313,22 @@ class Database:
         self.get_cursor().execute(f"DELETE FROM reminders WHERE id = {reminder_id}")
         self.database.commit()
 
+    # lastfm
+
+    def new_lastfm_data(self, user_id, lastfm_username):
+        self.get_cursor().execute(f"INSERT INTO lastfm (user_id, lastfm_user) VALUES ({user_id}, '{lastfm_username['user']['name']}')")
+        self.database.commit()
+
+    def update_lastfm_data(self, user_id, lastfm_username):
+        self.get_cursor().execute(f"UPDATE lastfm SET lastfm_user = '{lastfm_username['user']['name']}' WHERE user_id = '{user_id}'")
+        self.database.commit()
+
+    def get_lastfm_user_from_user_id(self, user_id):
+        cursor = self.get_cursor()
+        cursor.execute(f"SELECT lastfm_user FROM lastfm WHERE user_id = {user_id}")
+        lastfm_user = cursor.fetchone()
+        return lastfm_user if lastfm_user else None
+
     # misc
 
     def save_messages(self, ctx, buffer):

--- a/sql.py
+++ b/sql.py
@@ -316,11 +316,11 @@ class Database:
     # lastfm
 
     def new_lastfm_data(self, user_id, lastfm_username):
-        self.get_cursor().execute(f"INSERT INTO lastfm (user_id, lastfm_user) VALUES ({user_id}, '{lastfm_username['user']['name']}')")
+        self.get_cursor().execute(f"INSERT INTO lastfm (user_id, lastfm_user) VALUES ({user_id}, {sqlstr(lastfm_username)})")
         self.database.commit()
 
     def update_lastfm_data(self, user_id, lastfm_username):
-        self.get_cursor().execute(f"UPDATE lastfm SET lastfm_user = '{lastfm_username['user']['name']}' WHERE user_id = '{user_id}'")
+        self.get_cursor().execute(f"UPDATE lastfm SET lastfm_user = {sqlstr(lastfm_username)} WHERE user_id = {user_id}")
         self.database.commit()
 
     def get_lastfm_user_from_user_id(self, user_id):


### PR DESCRIPTION
Adds support for LastFM by using the LastFM API, which will let people link their LastFM account to the bot to be able to show whatever they're listening to in chat. Also I wasn't even able to test this again because something with osu broke that I was too lazy to fix, so let me know if it doesn't work on your end.

You will need to add `LASTFM_TOKEN` to your .env and get a token from [here](https://www.last.fm/api/account/create) (you'll need a LastFM account first)

Here's the database schema to add to your own database (I sure hope it's correct! As I said I wasn't able to really test anything since I couldn't get the bot running again)

``` sql
CREATE TABLE `lastfm` (
    -> `user_id` int unsigned NOT NULL DEFAULT '0',
    -> `lastfm_user` VARCHAR(36) DEFAULT NULL,
    -> PRIMARY KEY (`user_id`)
    -> ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
```

I completely messed up git while I tried to make this PR I think, so let me know if I horribly broke something. 

